### PR TITLE
userConfig priority for outDir

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "license": "MIT",
   "scripts": {
+    "prepare": "tsc",
     "build": "tsc"
   },
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ function esBuildSourceMapOptions(tsConfig: TSConfig) {
 function getBuildMetadata(userConfig: Config) {
   const { tsConfig, tsConfigFile } = getTSConfig();
 
-  const outDir = tsConfig.options.outDir || userConfig.outDir || "dist";
+  const outDir = userConfig.outDir || tsConfig.options.outDir || "dist";
 
   const esbuildEntryPoints = userConfig.esbuild?.entryPoints || [];
   const srcFiles = [...tsConfig.fileNames, ...esbuildEntryPoints];


### PR DESCRIPTION
the outDir config was being overridden by the tsconfig, and that should't happen, because it's useful for when you want to use, for example, esbuild-node-tsc for development builds, and regular tsc for prod builds (for declaration files), and pointing those at different directories.

(Also added the `prepare` script)