### PR TITLE
Fix sourcemap option, so compiled output includes sourceMappingUrl

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ function esBuildSourceMapOptions(tsConfig: TSConfig) {
   }
 
   if ((inlineSources && sourceMap) || sourceMap) {
-    return "external";
+    return true;
   }
 
   if (inlineSourceMap) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ function esBuildSourceMapOptions(tsConfig: TSConfig) {
     return false;
   }
 
-  if ((inlineSources && sourceMap) || sourceMap) {
+  if (sourceMap) {
     return true;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ function esBuildSourceMapOptions(tsConfig: TSConfig) {
   if (inlineSourceMap) {
     return "inline";
   }
-  
+
   return sourceMap;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,15 +42,11 @@ function esBuildSourceMapOptions(tsConfig: TSConfig) {
     return false;
   }
 
-  if (sourceMap) {
-    return true;
-  }
-
   if (inlineSourceMap) {
     return "inline";
   }
-
-  return false;
+  
+  return sourceMap;
 }
 
 function getBuildMetadata(userConfig: Config) {


### PR DESCRIPTION
When using `sourceMap=external`, esbuild does not generate the `//# sourceMappingURL=` comment, which tells tools like `source-map-support` where to look for source maps. I think this is always desirable, right?

https://esbuild.github.io/api/#sourcemap