### PR TITLE
Adds support for plugins option in esbuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,16 @@ But if things are not working as expected you can configure esbuild-node-tsc by 
 Example `etsc.config.js`
 
 ```js
+const esbuildPluginTsc = require('esbuild-plugin-tsc');
+
 module.exports = {
   outDir: "./dist",
   esbuild: {
     minify: false,
     target: "es2015",
+    plugins: [
+      esbuildPluginTsc(),
+    ],
   },
   assets: {
     baseDir: "src",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+import type { Plugin } from 'esbuild'
+
 export type Config = Partial<{
   outDir: string;
   tsConfigFile?: string;
@@ -5,6 +7,7 @@ export type Config = Partial<{
     entryPoints?: string[];
     minify?: boolean;
     target?: string;
+    plugins?: Plugin[]
   };
   assets: {
     baseDir?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,8 +61,8 @@ function getBuildMetadata(userConfig: Config) {
     userConfig.esbuild?.target ||
     tsConfig?.raw?.compilerOptions?.target ||
     "es6";
-
   const minify = userConfig.esbuild?.minify || false;
+  const plugins = userConfig.esbuild?.plugins || [];
 
   const esbuildOptions: BuildOptions = {
     outdir: outDir,
@@ -70,6 +70,7 @@ function getBuildMetadata(userConfig: Config) {
     sourcemap,
     target,
     minify,
+    plugins,
     tsconfig: tsConfigFile,
   };
 


### PR DESCRIPTION
The `plugins` option allows for incremental behavior with the esbuild compiler.

Addresses #11 