### PR TITLE
Don't silently fail on errors while requiring user config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,8 @@ export async function readUserConfig(configPath: string): Promise<Config> {
   try {
     return require(configPath);
   } catch (err) {
-    // Ignore the read error
+    console.error(err);
+    console.log('Using default config');
   }
   return {};
 }


### PR DESCRIPTION
Fixes #17 

I just added console logs, so everything stays backwards compatible.

I also decided not to edit README, since the nullish coalescing error thrown should already give enough context about the issue and how to resolve it.

