### PR TITLE
fix: don't log errors when using default config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,9 @@ export async function readUserConfig(configPath: string): Promise<Config> {
   try {
     return require(configPath);
   } catch (err) {
-    console.error(err);
+    if (err.code !== 'MODULE_NOT_FOUND') {
+      console.error(err);
+    }
     console.log('Using default config');
   }
   return {};


### PR DESCRIPTION
When I run `esbuild-node-tsc` without `etsc.config.js` I get following error in the console, even though the config file is optional.

```
$ esbuild-node-tsc
Error: Cannot find module '<redacted>/etsc.config.js'
Require stack:
- <redacted>/node_modules/esbuild-node-tsc/dist/config.js
- <redacted>/node_modules/esbuild-node-tsc/dist/index.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
    at Function.Module._load (internal/modules/cjs/loader.js:725:27)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (<redacted>/node_modules/esbuild-node-tsc/dist/config.js:16:20)
    at Generator.next (<anonymous>)
    at <redacted>/node_modules/esbuild-node-tsc/dist/config.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (<redacted>/node_modules/esbuild-node-tsc/dist/config.js:4:12)
    at Object.readUserConfig (<redacted>/node_modules/esbuild-node-tsc/dist/config.js:14:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '<redacted>/node_modules/esbuild-node-tsc/dist/config.js',
    '<redacted>/node_modules/esbuild-node-tsc/dist/index.js'
  ]
}
Using default config
Built in: 93.403ms
```