### PR TITLE
Fix: Copy assets with proper parents directory structure

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,7 @@ async function copyNonSourceFiles({
   const relativeOutDir = path.relative(baseDir, outDir);
   return await cpy(patterns, relativeOutDir, {
     cwd: baseDir,
+    parents: true
   });
 }
 


### PR DESCRIPTION
## Description
Fixes the issue with keeping proper directory structure when copying the assets


### Expectation
With the following config
```
...
assets: {
        baseDir: 'src',
        outDir: 'build',
        filePatterns: ['**/*.json', '**/*.html'],
},
...
```
it's expected that the matched assets are copied into respective sub-directories